### PR TITLE
Remove saving JobId to a file

### DIFF
--- a/run-job-v2.sh
+++ b/run-job-v2.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+source bootstrap.sh "$@"
+
+if [ "$BEARER_TOKEN" == "null" ]
+then
+    printf "Failed to retrieve bearer token is base64 token accurate?\nIs %s available from this computer?\n", $IDP_URL
+    exit 1
+fi
+
+echo "Using okta url: $IDP_URL"
+echo "Connecting to AB2D API at: $API_URL"
+echo "Saving data to: $DIRECTORY"
+echo "FHIR Version: $FHIR_VERSION"
+
+# ------ Starting job
+
+echo "Starting job"
+# Parameters:
+#   1 - URL to run against
+#   2 - Base64 encoded clientId:clientPassword
+
+source fn_get_token.sh
+
+# Refresh bearer token
+BEARER_TOKEN=$(fn_get_token "$IDP_URL" "$AUTH_FILE")
+if [ "$BEARER_TOKEN" == "null" ]
+then
+  printf "Failed to retrieve bearer token is base64 token accurate?\nIs %s available from this computer?\n", $IDP_URL
+  exit 1
+fi
+
+URL="${API_URL}/Patient/\$export?_outputFormat=application%2Ffhir%2Bndjson&_type=ExplanationOfBenefit"
+
+# If a date is provided
+if [ "$SINCE" != '' ]; then
+  URL="$URL&_since=$SINCE"
+fi
+
+echo "Attempting to start job using $URL"
+
+RESULT=$(curl "$URL" \
+    -sD - \
+    -H "accept: application/json" \
+    -H "Accept: application/fhir+json" \
+    -H "Prefer: respond-async" \
+    -H "Authorization: Bearer ${BEARER_TOKEN}")
+
+echo "$RESULT"
+
+HTTP_CODE=$(echo "$RESULT" | grep "HTTP/" | awk  '{print $2}')
+if [ "$HTTP_CODE" != 202 ]
+then
+    echo "Could not export job"
+else
+    JOB=$(echo "$RESULT" | grep "\(content-location\|Content-Location\)" | sed 's/.*Job.//' | sed 's/..status//' | tr -d '[:space:]')
+
+    if [ "$JOB" == '' ]
+    then
+      echo "Could not parse response for job id. Make sure to save the job id located on the line with 'content-location'"
+      exit 1
+    fi
+
+    echo "$JOB created"
+fi
+
+
+# ------ Monitoring job
+echo "Monitoring job with job id $JOB"
+
+# Get the status
+RESPONSE=$(curl "${API_URL}/Job/${JOB}/\$status" -sD - -H "accept: application/json" -H "Authorization: Bearer ${BEARER_TOKEN}")
+URLS=$(echo "$RESPONSE" | grep ExplanationOfBenefit)
+
+sleep 5
+
+# If there are no results, wait x seconds and try again
+while [ "$URLS" == '' ]
+do
+    # If response is unauthorized refresh token and try again
+    HTTP_CODE=$(echo "$RESPONSE" | grep "HTTP/" | awk  '{print $2}')
+
+    if [ "$HTTP_CODE" == 403 ]
+    then
+        echo "Token expired refreshing and then attempting to check status again"
+        BEARER_TOKEN=$(fn_get_token "$IDP_URL" "$AUTH_FILE")
+        sleep 30
+        RESPONSE=$(curl "${API_URL}/Job/${JOB}/\$status" -sD - -H "accept: application/json" -H "Authorization: Bearer ${BEARER_TOKEN}")
+    elif [ "$HTTP_CODE" != 202 ] && [ "$HTTP_CODE" != 200 ]
+    then
+        echo "Error making rest call $HTTP_CODE"
+        echo "Exiting without saving results"
+        exit 1
+    else
+
+        echo "$RESPONSE"
+        URLS=$(echo "$RESPONSE" | grep ExplanationOfBenefit)
+
+        # Sleep and increment counter
+        if [ "$URLS" == '' ]
+        then
+            sleep 60
+
+            COUNTER=$(( COUNTER +1 ))
+
+            # Log every ten seconds
+            if [ $((COUNTER % 10)) == 0 ]
+            then
+              echo "Running for $COUNTER minutes"
+            fi
+
+            RESPONSE=$(curl "${API_URL}/Job/${JOB}/\$status" -sD - -H "accept: application/json" -H "Authorization: Bearer ${BEARER_TOKEN}")
+        fi
+
+    fi
+done
+
+echo "Job finished with
+$RESPONSE"
+
+echo "$RESPONSE" > "$DIRECTORY/response.json"
+
+echo "Saved response to $DIRECTORY/response.json"
+
+# ------ Download results for job
+echo "Download results for job"
+
+URLS=$(cat "$DIRECTORY/response.json" | grep ExplanationOfBenefit | jq --raw-output ".output[].url")
+
+# Download each file by url
+COUNTER=0
+
+echo "List of files to download $URLS"
+
+for URL in ${URLS}
+do
+    FILE_NAME="$DIRECTORY"/$(echo ${URL} | sed 's/.*.file.//')
+
+    echo "$URL"
+
+    if [ -f "$FILE_NAME" ]
+    then
+        echo "$FILE_NAME already exists, skipping"
+    else
+        curl --header "Accept: application/fhir+ndjson" \
+          --header "Authorization: Bearer ${BEARER_TOKEN}" \
+          "$URL" > "$FILE_NAME"
+
+        COUNTER=$(( COUNTER +1 ))
+
+        echo "Updating bearer token"
+        BEARER_TOKEN=$(fn_get_token "$IDP_URL" "$AUTH_FILE")
+    fi
+done
+
+

--- a/run-job-v2.sh
+++ b/run-job-v2.sh
@@ -32,9 +32,8 @@ fi
 
 echo "Attempting to start job using $URL"
 
-PATIENT_HEADERS_FILE="$DIRECTORY/patient_response_headers.txt"
+PATIENT_HEADERS_FILE="$DIRECTORY/patient_headers.txt"
 HTTP_CODE=$(curl "$URL" \
-    -v \
     -s \
     -w "%{http_code}" \
     -D "$PATIENT_HEADERS_FILE" \
@@ -57,60 +56,63 @@ else
       echo "Could not parse response for job id. Make sure to save the job id located on the line with 'content-location'"
       exit 1
     fi
-
-    echo "$JOB created"
 fi
 
 # ------ Monitoring job
 echo "Monitoring job with job id $JOB"
 
-URLS_HEADER=""
-JOB_HEADERS_FILE="$DIRECTORY/job_response_headers.txt"
+JOB_HEADERS_FILE="$DIRECTORY/job_headers.txt"
+JOB_RESPONSE_FILE="$DIRECTORY/job_response.txt"
+
+# Empty response file to avoid getting URLs from a previous run
+echo -n "" > "$JOB_RESPONSE_FILE"
+
+JOB_JSON=""
 COUNTER=0
 
-while [ "$URLS_HEADER" == '' ]
-do
+while [ "$JOB_JSON" == '' ]; do
     # Sleep and increment counter
     sleep 60
     COUNTER=$(( COUNTER +1 ))
     echo "Running for $COUNTER minutes"
 
     HTTP_CODE=$(curl "${API_URL}/Job/${JOB}/\$status" \
-        -v \
         -s \
         -w "%{http_code}" \
         -D "$JOB_HEADERS_FILE" \
+        -o "$JOB_RESPONSE_FILE" \
         -H "accept: application/json" \
         -H "Authorization: Bearer ${BEARER_TOKEN}")
 
     cat "$JOB_HEADERS_FILE"
+    cat "$JOB_RESPONSE_FILE"
 
     if [ "$HTTP_CODE" == 403 ]; then
         # If response is unauthorized refresh token and try again
         echo "Token expired. Refreshing and then attempting to check status again"
-        BEARER_TOKEN=$(fn_get_token "$IDP_URL" "$AUTH_FILE")
+        BEARER_TOKEN="$(fn_get_token "$IDP_URL" "$AUTH_FILE")"
     elif [ "$HTTP_CODE" != 202 ] && [ "$HTTP_CODE" != 200 ]; then
         echo "Error making rest call. Status code: $HTTP_CODE"
         exit 1
     else
-        URLS_HEADER="$(grep ExplanationOfBenefit "$JOB_HEADERS_FILE")"
+        JOB_JSON="$(grep ExplanationOfBenefit "$JOB_RESPONSE_FILE")"
     fi
 done
 
-echo "Saved response to $JOB_HEADERS_FILE"
+echo "Saved response to $JOB_RESPONSE_FILE"
 
 # ------ Download results for job
 echo "Downloading results for job"
 
-URLS=$(echo "$URLS_HEADER" | jq --raw-output ".output[].url")
+URLS="$(echo "$JOB_JSON" | jq --raw-output ".output[].url")"
 echo "List of files to download: $URLS"
 FILE_DOWNLOAD_HEADERS="$DIRECTORY/file_download_headers.txt"
 COUNTER=0
 
 for URL in $URLS; do
-    FILE_NAME="$DIRECTORY"/$(echo ${URL} | sed 's/.*.file.//')
+    FILE_NAME="$DIRECTORY/$(echo "$URL" | sed 's/.*.file.//')"
 
-    echo "Downloading file from $URL"
+    echo "Downloading file to $FILE_NAME from $URL"
 
     if [ -f "$FILE_NAME" ]; then
         echo "$FILE_NAME already exists, skipping"
@@ -126,7 +128,7 @@ for URL in $URLS; do
             if [ "$HTTP_CODE" == 403 ]; then
                 # If response is unauthorized refresh token and try again
                 echo "Bearer token expired. Refreshing, then attempting to download again"
-                BEARER_TOKEN=$(fn_get_token "$IDP_URL" "$AUTH_FILE")
+                BEARER_TOKEN="$(fn_get_token "$IDP_URL" "$AUTH_FILE")"
             elif [ "$HTTP_CODE" != 200 ]; then
                 echo "Error downloading file. Status code: $HTTP_CODE"
                 cat "$FILE_DOWNLOAD_HEADERS"

--- a/run-job-v2.sh
+++ b/run-job-v2.sh
@@ -86,6 +86,7 @@ while [ "$JOB_JSON" == '' ]; do
 
     cat "$JOB_HEADERS_FILE"
     cat "$JOB_RESPONSE_FILE"
+    echo  # Add newline after response output
 
     if [ "$HTTP_CODE" == 403 ]; then
         # If response is unauthorized refresh token and try again

--- a/run-job-v2.sh
+++ b/run-job-v2.sh
@@ -40,6 +40,7 @@ fi
 echo "Attempting to start job using $URL"
 
 RESULT=$(curl "$URL" \
+    -v \
     -sD - \
     -H "accept: application/json" \
     -H "Accept: application/fhir+json" \
@@ -69,7 +70,7 @@ fi
 echo "Monitoring job with job id $JOB"
 
 # Get the status
-RESPONSE=$(curl "${API_URL}/Job/${JOB}/\$status" -sD - -H "accept: application/json" -H "Authorization: Bearer ${BEARER_TOKEN}")
+RESPONSE=$(curl "${API_URL}/Job/${JOB}/\$status" -v -sD - -H "accept: application/json" -H "Authorization: Bearer ${BEARER_TOKEN}")
 URLS=$(echo "$RESPONSE" | grep ExplanationOfBenefit)
 
 sleep 5
@@ -85,7 +86,7 @@ do
         echo "Token expired refreshing and then attempting to check status again"
         BEARER_TOKEN=$(fn_get_token "$IDP_URL" "$AUTH_FILE")
         sleep 30
-        RESPONSE=$(curl "${API_URL}/Job/${JOB}/\$status" -sD - -H "accept: application/json" -H "Authorization: Bearer ${BEARER_TOKEN}")
+        RESPONSE=$(curl "${API_URL}/Job/${JOB}/\$status" -v -sD - -H "accept: application/json" -H "Authorization: Bearer ${BEARER_TOKEN}")
     elif [ "$HTTP_CODE" != 202 ] && [ "$HTTP_CODE" != 200 ]
     then
         echo "Error making rest call $HTTP_CODE"
@@ -109,7 +110,7 @@ do
               echo "Running for $COUNTER minutes"
             fi
 
-            RESPONSE=$(curl "${API_URL}/Job/${JOB}/\$status" -sD - -H "accept: application/json" -H "Authorization: Bearer ${BEARER_TOKEN}")
+            RESPONSE=$(curl "${API_URL}/Job/${JOB}/\$status" -v -sD - -H "accept: application/json" -H "Authorization: Bearer ${BEARER_TOKEN}")
         fi
 
     fi

--- a/run-job-v2.sh
+++ b/run-job-v2.sh
@@ -2,12 +2,6 @@
 
 source bootstrap.sh "$@"
 
-if [ "$BEARER_TOKEN" == "null" ]
-then
-    printf "Failed to retrieve bearer token is base64 token accurate?\nIs %s available from this computer?\n", $IDP_URL
-    exit 1
-fi
-
 echo "Using okta url: $IDP_URL"
 echo "Connecting to AB2D API at: $API_URL"
 echo "Saving data to: $DIRECTORY"

--- a/run-job-v2.sh
+++ b/run-job-v2.sh
@@ -122,7 +122,7 @@ for URL in $URLS; do
                 -w "%{http_code}" \
                 -o "$FILE_NAME" \
                 -D "$FILE_DOWNLOAD_HEADERS" \
-                -H "Accept: application/fhir+json" \
+                -H "Accept: application/fhir+ndjson" \
                 -H "Authorization: Bearer ${BEARER_TOKEN}")
 
             if [ "$HTTP_CODE" == 403 ]; then


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5801

## 🛠 Changes

Merged start-job.sh, monitor-job.sh and download-result.sh to 1 script
Removed writing JobId to a file

## ℹ️ Context for reviewers

Change for Centene

## ✅ Acceptance Validation

The new script does not write the JobId to the file.
All other functionality remains the same.
Tested manually 

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
