### PR TITLE
AB2D-6108 TIBQ: ab2d-sample-client-bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Until:
 If you only want claims data updated or filed before a certain date use the `--until` parameter. The expected format follows the typical
 ISO date time format of `yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ`.
 
-For requests using FHIR R4, a default `_until` value is supplied if one is not provided. The value of the default `_until`
-parameter is set to the current date and time.
+This parameter is only available with V2 (FHIR R4). 
+If no `_until` date is specified or you use a date from the future, it will default to the current date and time.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ For requests using FHIR R4, a default `_since` value is supplied if one is not p
 parameter is set to the creation date and time of a contract’s last successfully searched and downloaded job.
 
 Examples:
+
 1. March 1, 2020 at 3 PM EST -> `2020-03-01T15:00:00.000-05:00`
 2. May 31, 2020 at 4 AM PST -> `2020-05-31T04:00:00-08:00`
 
@@ -85,7 +86,7 @@ Example:
 
 If you want to:
 1. Start a job running against production
-2. Using credentials in `my-orgs-creds.base64`
+2. Use credentials in `my-orgs-creds.base64`
 3. Save all results for this job to the directory /opt/foo
 4. And only get data after April 1st 2020 at 9:00 AM Eastern Time
 
@@ -101,12 +102,13 @@ source ./bootstrap.sh -prod --auth my-orgs-creds.base64 --directory /opt/foo --f
 Until:
 
 If you only want claims data updated or filed before a certain date use the `--until` parameter. The expected format follows the typical
-ISO date time format of `yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ`
+ISO date time format of `yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ`.
 
 For requests using FHIR R4, a default `_until` value is supplied if one is not provided. The value of the default `_until`
 parameter is set to the current date and time.
 
 Examples:
+
 1. March 1, 2020 at 3 PM EST -> `2020-03-01T15:00:00.000-05:00`
 2. May 31, 2020 at 4 AM PST -> `2020-05-31T04:00:00-08:00`
 
@@ -125,7 +127,7 @@ Example:
 
 If you want to:
 1. Start a job running against production
-2. Using credentials in `my-orgs-creds.base64`
+2. Use credentials in `my-orgs-creds.base64`
 3. Save all results for this job to the directory /opt/foo
 4. And only get data after April 1st 2020 at 9:00 AM Eastern Time and before June 1st 2020 at 9:00 AM Eastern Time
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This script will not overwrite already existing export files.
 ```
 Usage: 
   bootstrap (-prod | -sandbox) --auth <auth.base64> [--directory <dir>] [--since <since>] --fhir (STU3 | R4)
-  run-job (-prod | -sandbox) --auth <auth.base64> [--directory <dir>] [--since <since>] --fhir (STU3 | R4)
+  run-job (-prod | -sandbox) --auth <auth.base64> [--directory <dir>] [--since <since>] [--until <until>] --fhir (STU3 | R4)
   start-job
   monitor-job
   download-results
@@ -45,6 +45,10 @@ Arguments:
   --since     -- if you only want claims data updated or filed after a certain date specify this parameter.
                  The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
                  Example March 1, 2020 at 3 PM EST -> 2020-03-01T15:00:00.000-05:00
+  --until     -- if you only want claims data updated or filed before a certain date specify this parameter.
+                 This parameter is only available with version 2 (FHIR R4) of the API.
+                 The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
+                 Example March 1, 2024 at 3 PM EST -> 2024-03-01T15:00:00.000-05:00
   --fhir      -- The FHIR version
 
 ```
@@ -94,6 +98,47 @@ source ./bootstrap.sh -prod --auth my-orgs-creds.base64 --directory /opt/foo --f
 ./download-results.sh
  ```
 
+Until:
+
+If you only want claims data updated or filed before a certain date use the `--until` parameter. The expected format follows the typical
+ISO date time format of `yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ`
+
+For requests using FHIR R4, a default `_until` value is supplied if one is not provided. The value of the default `_until`
+parameter is set to the current date and time.
+
+Examples:
+1. March 1, 2020 at 3 PM EST -> `2020-03-01T15:00:00.000-05:00`
+2. May 31, 2020 at 4 AM PST -> `2020-05-31T04:00:00-08:00`
+
+Files:
+
+1. <directory>/jobId.txt -- id of the job created
+2. <directory>/response.json -- list of files to download
+3. <directory>/*.ndjson -- downloaded results of exports
+
+Limitations:
+
+1. Assumes all scripts use the same directory
+2. Assumes all scripts use the same base64 encoded AUTH token saved to a file
+
+Example:
+
+If you want to:
+1. Start a job running against production
+2. Using credentials in `my-orgs-creds.base64`
+3. Save all results for this job to the directory /opt/foo
+4. And only get data after April 1st 2020 at 9:00 AM Eastern Time and before June 1st 2020 at 9:00 AM Eastern Time
+
+Then run the following command
+
+```
+source ./bootstrap.sh -prod --auth my-orgs-creds.base64 --directory /opt/foo --fhir R4 --since 2020-04-01T09:00:00.000--05:00 --until 2020-06-01T09:00:00.000--05:00
+./start-job.sh 
+./monitor-job.sh 
+./download-results.sh
+ ```
+
+
 ## Creating the Base64 credentials file
 
 1. Set the OKTA_CLIENT_ID and OKTA_CLIENT_PASSWORD
@@ -136,7 +181,7 @@ This is the preferred way to run a job.
 2. Set the `AUTH_FILE=<auth-file>`
 3. Create the AUTH token `echo -n "${OKTA_CLIENT_ID}:${OKTA_CLIENT_PASSWORD}" | base64 > $AUTH_FILE`
    and copy it to a file. Example file: `auth-token.base64`.
-4. Run `./run-job.sh -prod --directory <directory> --auth $AUTH_FILE --fhir R4 --since 2020-02-13T00:00:00.000-05:00` to start,
+4. Run `./run-job.sh -prod --directory <directory> --auth $AUTH_FILE --fhir R4 --since 2020-02-13T00:00:00.000-05:00 --until 2020-06-01T00:00:00.000-05:00` to start,
    monitor, and download results from a job.
 
 ### Running Scripts Individually
@@ -151,7 +196,7 @@ This is for developer debugging purpose.
 2. Set the `AUTH_FILE=<auth-file>` 
 3. Create the AUTH token `echo -n "${OKTA_CLIENT_ID}:${OKTA_CLIENT_PASSWORD}" | base64 > $AUTH_FILE`
 and copy it to a file. Example file: `auth-token.base64`.
-4. Run `source bootstrap.sh -prod --directory <directory> --auth $AUTH_FILE --fhir R4 --since 2020-02-13T00:00:00.000-05:00` to set environment variables for a job.
+4. Run `source bootstrap.sh -prod --directory <directory> --auth $AUTH_FILE --fhir R4 --since 2020-02-13T00:00:00.000-05:00 --until 2020-06-01T00:00:00.000-05:00` to set environment variables for a job.
 5. Run `./start-job.sh` to start a job. If successful a file containing
 the job id will be saved in `<directory>/jobId.txt`
 6. Run `./monitor-job.sh` which will monitor the state of the running job. When the job

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,7 +4,7 @@ if [ "$1" == "--help" ]
 then
   printf \
 "Usage: \n
-  <command> (-prod | -sandbox) --auth <passwordfile.base64> [--directory <dir>] [--since <since>] --fhir (R4 | STU3)\n
+  <command> (-prod | -sandbox) --auth <passwordfile.base64> [--directory <dir>] [--since <since>] [--until <until>] --fhir (R4 | STU3)\n
 Arguments:\n
   -sandbox    -- if running against ab2d sandbox environment
   -prod       -- if running against ab2d production environment
@@ -13,6 +13,10 @@ Arguments:\n
   --since     -- if you only want claims data updated or filed after a certain date specify this parameter.
                  The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
                  Example March 1, 2020 at 3 PM EST -> 2020-03-01T15:00:00.000-05:00
+  --until     -- if you only want claims data updated or filed before a certain date specify this parameter.
+                 This parameter is only available with version 2 (FHIR R4) of the API.
+                 The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
+                 Example March 1, 2024 at 3 PM EST -> 2024-03-01T15:00:00.000-05:00
   --fhir      -- The FHIR version\n\n"
   exit 0;
 fi
@@ -42,6 +46,10 @@ do
       export SINCE=$(echo "$2" | sed "s/:/%3A/g")
       shift
       ;;
+    "--until")
+      export UNTIL=$(echo "$2" | sed "s/:/%3A/g")
+      shift
+      ;;
     "--fhir")
       export FHIR_VERSION=$2
       shift
@@ -61,7 +69,12 @@ then
   error=true
   printf "The FHIR version must be specified --fhir [R4 | STU3]\n"
 fi
-if ($error == true)
+if [ "${FHIR_VERSION}" == "STU3" ] && [ "${UNTIL}" != "" ]
+then
+  error=true
+  printf "The _until parameter is only available with version 2 (FHIR R4) of the API\n"
+fi
+if [ "${error}" == true ]
 then
   exit 1
 fi

--- a/monitor-job.sh
+++ b/monitor-job.sh
@@ -11,6 +11,12 @@ fi
 
 JOB=$(cat "$DIRECTORY/jobId.txt")
 
+if [ "$JOB" == "" ]
+then
+    printf "Failed to retrieve job ID from jobId.txt\n"
+    exit 1
+fi
+
 echo "Id of job being monitored $JOB"
 
 # Get the status

--- a/run-job.sh
+++ b/run-job.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# the -e flag tells the script to exit if any of its commands exit with a non zero code.
+# For instance, if any of the subscripts exit with a 1 (like if we fail to export a job)
+# we should exit this script automatically. 
+set -e
+
 source bootstrap.sh "$@"
 
 if [ "$BEARER_TOKEN" == "null" ]

--- a/start-job.sh
+++ b/start-job.sh
@@ -20,6 +20,10 @@ if [ "$SINCE" != '' ]; then
   URL="$URL&_since=$SINCE"
 fi
 
+if [ "$UNTIL" != '' ]; then
+  URL="$URL&_until=$UNTIL"
+fi
+
 echo "Attempting to start job using $URL"
 
 RESULT=$(curl "$URL" \

--- a/start-job.sh
+++ b/start-job.sh
@@ -39,6 +39,7 @@ HTTP_CODE=$(echo "$RESULT" | grep "HTTP/" | awk  '{print $2}')
 if [ "$HTTP_CODE" != 202 ]
 then
     echo "Could not export job"
+    exit 1
 else
     JOB=$(echo "$RESULT" | grep "\(content-location\|Content-Location\)" | sed 's/.*Job.//' | sed 's/..status//' | tr -d '[:space:]')
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6108

## 🛠 Changes

- Added _until parameter to bootstrap.sh and start-job.sh

## ℹ️ Context

Currently, AB2D API only accepts _since as a date parameter. The goal is for AB2D to be able to support the use case where a PDP could run jobs with time interval based queries so that they could download their data in batches. To achieve that, we will add a _until parameter to define the upper ceiling of the date range. 

Both the since and _until parameter will be applied to the lastupdated_Date. 

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<img width="1176" alt="Screenshot 2024-07-18 at 2 50 50 PM" src="https://github.com/user-attachments/assets/2bfbcaa3-ad8f-4bf1-82ea-b21c06be2aae">

