### PR TITLE
AB2D-6945 Update sample clients to support v3 API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This may be a great starting point for your engineering or development teams how
 Use of these clients in the sandbox environment allows for safe testing and ensures no PII/PHI will not be compromised if a mistake is made.
 The sandbox environment is publicly available and all the data in it is synthetic (**not** real)
 
-AB2D supports both R4 and STU3 versions of the FHIR standard. FHIR R4 is available using v2 of AB2D while FHIR STU3 can 
-be accessed via AB2D v1. Accordingly, this client supports both R4/v2 and STU3/v1.
+AB2D supports both R4 and STU3 versions of the FHIR standard. FHIR R4 is available using v2 and v3 of AB2D while FHIR STU3 can 
+be accessed via AB2D v1. Accordingly, this client supports R4/v3, R4/v2 and STU3/v1.
 
 ## Production Use Disclaimer:
 
@@ -30,8 +30,8 @@ This script will not overwrite already existing export files.
 
 ```
 Usage: 
-  bootstrap (-prod | -sandbox) --auth <auth.base64> [--directory <dir>] [--since <since>] --fhir (STU3 | R4)
-  run-job (-prod | -sandbox) --auth <auth.base64> [--directory <dir>] [--since <since>] [--until <until>] --fhir (STU3 | R4)
+  bootstrap (-prod | -sandbox) --auth <auth.base64> [--directory <dir>] [--since <since>] --fhir (STU3 | R4) [--ab2d-endpoint (v2 | v3)]
+  run-job (-prod | -sandbox) --auth <auth.base64> [--directory <dir>] [--since <since>] [--until <until>] --fhir (STU3 | R4) [--ab2d-endpoint (v2 | v3)]
   start-job
   monitor-job
   download-results
@@ -51,6 +51,7 @@ Arguments:
                  The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
                  Example March 1, 2024 at 3 PM EST -> 2024-03-01T15:00:00.000-05:00
   --fhir      -- The FHIR version
+  --ab2d-endpoint -- AB2D API endpoint version when using FHIR R4 (v2 | v3). Defaults to v2 if not specified.
 
 ```
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,21 +4,24 @@ if [ "$1" == "--help" ]
 then
   printf \
 "Usage: \n
-  <command> (-prod | -sandbox) --auth <passwordfile.base64> [--directory <dir>] [--gzip] [--since <since>] [--until <until>] --fhir (R4 | STU3)\n
+  <command> (-prod | -sandbox) --auth <passwordfile.base64> [--directory <dir>] [--gzip] [--since <since>]
+  [--until <until>] --fhir (R4 | STU3) [--ab2d-endpoint (v2 | v3)] \n
 Arguments:\n
-  -sandbox    -- if running against ab2d sandbox environment
-  -prod       -- if running against ab2d production environment
-  --auth      -- base64 encoded \"clientid:password\"
-  --directory -- if you want files and job info saved to specific directory
-  --gzip      -- if you want to download files in compressed gzip format
-  --since     -- if you only want claims data updated or filed after a certain date specify this parameter.
-                 The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
-                 Example March 1, 2020 at 3 PM EST -> 2020-03-01T15:00:00.000-05:00
-  --until     -- if you only want claims data updated or filed before a certain date specify this parameter.
-                 This parameter is only available with version 2 (FHIR R4) of the API.
-                 The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
-                 Example March 1, 2024 at 3 PM EST -> 2024-03-01T15:00:00.000-05:00
-  --fhir      -- The FHIR version\n\n"
+  -sandbox        -- if running against ab2d sandbox environment
+  -prod           -- if running against ab2d production environment
+  --auth          -- base64 encoded \"clientid:password\"
+  --directory     -- if you want files and job info saved to specific directory
+  --gzip          -- if you want to download files in compressed gzip format
+  --since         -- if you only want claims data updated or filed after a certain date specify this parameter.
+                     The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
+                     Example March 1, 2020 at 3 PM EST -> 2020-03-01T15:00:00.000-05:00
+  --until         -- if you only want claims data updated or filed before a certain date specify this parameter.
+                     This parameter is only available with version 2 (FHIR R4) of the API.
+                     The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ.
+                     Example March 1, 2024 at 3 PM EST -> 2024-03-01T15:00:00.000-05:00
+  --fhir          -- The FHIR version
+  --ab2d-endpoint -- AB2D API endpoint version when using FHIR R4 (v2 | v3). Defaults to v2 if not specified.\n\n"
+
   exit 0;
 fi
 
@@ -57,6 +60,10 @@ do
       export FHIR_VERSION=$2
       shift
       ;;
+    "--ab2d-endpoint")
+      export AB2D_ENDPOINT=$2
+      shift
+      ;;
     "--gzip")
       export AB2D_USE_GZIP='true'
       ;;
@@ -80,6 +87,21 @@ then
   error=true
   printf "The _until parameter is only available with version 2 (FHIR R4) of the API\n"
 fi
+
+if [ "${FHIR_VERSION}" == "R4" ]
+then
+  if [ "${AB2D_ENDPOINT}" == "" ]
+  then
+    AB2D_ENDPOINT="v2"
+  fi
+
+  if [ "${AB2D_ENDPOINT}" != "v2" ] && [ "${AB2D_ENDPOINT}" != "v3" ]
+  then
+    error=true
+    printf "When using FHIR R4, --ab2d-endpoint must be one of: v2 | v3\n"
+  fi
+fi
+
 if [ "${error}" == true ]
 then
   exit 1
@@ -87,7 +109,7 @@ fi
 
 if [ "${FHIR_VERSION}" == "R4" ]
 then
-  export API_URL="${API_URL_PT1}v2/fhir"
+  export API_URL="${API_URL_PT1}${AB2D_ENDPOINT}/fhir"
 else
   export API_URL="${API_URL_PT1}v1/fhir"
 fi

--- a/download-results-v2.sh
+++ b/download-results-v2.sh
@@ -76,7 +76,7 @@ fi
 echo "Downloading results for job: $JOB_ID"
 
 FILE_DOWNLOAD_HEADERS="$DIRECTORY/file_download_headers.txt"
-COMMON_URL="https://api.ab2d.cms.gov/api/v2/fhir/Job/$JOB_ID/file"
+COMMON_URL="https://api.ab2d.cms.gov/api/$AB2D_ENDPOINT/fhir/Job/$JOB_ID/file"
 
 COUNTER=0
 

--- a/run-job.sh
+++ b/run-job.sh
@@ -17,6 +17,7 @@ echo "Using okta url: $IDP_URL"
 echo "Connecting to AB2D API at: $API_URL"
 echo "Saving data to: $DIRECTORY"
 echo "FHIR Version: $FHIR_VERSION"
+echo "AB2D Endpoint: $AB2D_ENDPOINT"
 
 echo "Starting job"
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6945

## 🛠 Changes

Added parameter for the AB2D API version.

## ℹ️ Context

Currently the user only provides the --fhir parameter (STU3 or R4).
For the v3 update, we need a new parameter to distinguish between v2 and v3 when the user selects R4.

## 🧪 Validation

<img width="1178" height="206" alt="Screenshot 2025-11-19 at 12 58 45 PM" src="https://github.com/user-attachments/assets/db8f1f8c-9118-4740-ae15-84a791e0027a" />

